### PR TITLE
Make usage of all configured interfaces safer

### DIFF
--- a/config.c
+++ b/config.c
@@ -217,9 +217,6 @@ configure_interface(iflist)
 	struct dhcp6_ifconf *ifc;
 	char *cp;
 
-	/* XXX pointer back for use by dhcp6c interface names */
-	ifnames = iflist;
-
 	for (ifp = iflist; ifp; ifp = ifp->next) {
 		struct cf_list *cfl;
 
@@ -386,6 +383,14 @@ configure_interface(iflist)
 					"invalid interface configuration",
 					configfilename, cfl->line);
 				goto bad;
+			}
+		}
+
+		if (use_all_config_if) {
+			if (ifinit(ifp->name) == NULL) {
+				d_printf(LOG_ERR, FNAME, "failed to initialize %s", ifp->name);
+				/* safe to exit here as still parsing */
+				exit(1);
 			}
 		}
 	}

--- a/config.h
+++ b/config.h
@@ -310,7 +310,7 @@ extern struct dhcp6_list nispnamelist;
 extern struct dhcp6_list bcmcslist;
 extern struct dhcp6_list bcmcsnamelist;
 extern long long optrefreshtime;
-extern struct cf_namelist *ifnames;
+extern int use_all_config_if;
 
 struct dhcp6_if *ifinit(char *);
 int ifreset(struct dhcp6_if *);

--- a/dhcp6c.c
+++ b/dhcp6c.c
@@ -135,7 +135,12 @@ static int set_auth(struct dhcp6_event *, struct dhcp6_optinfo *);
 struct dhcp6_timer *client6_timo(void *);
 int client6_start(struct dhcp6_if *);
 static void info_printf(const char *, ...);
-struct cf_namelist *ifnames;
+
+static void init_cli_if(int argc, char **argv);
+
+int use_all_config_if;
+static int saved_cli_if_count;
+static char **saved_cli_if;
 
 #define MAX_ELAPSED_TIME 0xffff
 
@@ -145,7 +150,6 @@ main(int argc, char *argv[])
 	int ch, pid;
 	char *progname;
 	FILE *pidfp;
-	struct dhcp6_if *ifp;
 	struct cf_namelist *ifnamep;
 
 #ifndef HAVE_ARC4RANDOM
@@ -196,33 +200,21 @@ main(int argc, char *argv[])
 	client6_init();
 
 	/*
-	 * Doing away with the need for command line interfaces
-	 * We need to read the config file to get the names of the interfaces.
+	 * Doing away with the need for command line interfaces If this is set
+	 * config.c initializes the interface after parsing it.	This makes cfparse.y
+	 * have valid entries in dhcp6_if before it invokes configure_commit() at the
+	 * end of it's parse. Only one parse pass needed now.
 	 */
-	if (argc == 0) {
-		if (infreq_mode == 0 && (cfparse(conffile)) != 0) {
-			d_printf(LOG_ERR, FNAME, "failed to parse configuration file");
-			exit(1);
-		}
-		for (ifnamep = ifnames; ifnamep; ifnamep = ifnamep->next) {
-			if ((ifp = ifinit(ifnamep->name)) == NULL) {
-				d_printf(LOG_ERR, FNAME,
-				    "failed to initialize %s", ifnamep->name);
-				exit(1);
-			}
-		}
+	use_all_config_if = (argc == 0);
+
+	if (!use_all_config_if) {
+		saved_cli_if = argv;
+		saved_cli_if_count = argc;
+		init_cli_if(saved_cli_if_count, saved_cli_if);
+
 	}
 
-	while (argc-- > 0) {
-		if ((ifp = ifinit(argv[0])) == NULL) {
-			d_printf(LOG_ERR, FNAME, "failed to initialize %s",
-			    argv[0]);
-			exit(1);
-		}
-		argv++;
-	}
-
-	if (infreq_mode == 0 && (cfparse(conffile)) != 0) {
+	if (infreq_mode == 0 && cfparse(conffile)) {
 		d_printf(LOG_ERR, FNAME, "failed to parse configuration file");
 		exit(1);
 	}
@@ -253,6 +245,18 @@ usage()
 }
 
 /*------------------------------------------------------------*/
+
+static void
+init_cli_if(int argc, char **argv) {
+	while (argc-- > 0) {
+		if (ifinit(argv[0]) == NULL) {
+			d_printf(LOG_ERR, FNAME, "failed to initialize %s",
+			    argv[0]);
+			exit(1);
+		}
+		argv++;
+	}
+}
 
 void
 client6_init(void)
@@ -501,18 +505,10 @@ process_signals(void)
 	if ((sig_flags & SIGF_HUP)) {
 		d_printf(LOG_INFO, FNAME, "restarting");
 		free_resources(NULL);
-		if (infreq_mode == 0 && (cfparse(conffile)) != 0) {
-			d_printf(LOG_WARNING, FNAME,
-			    "failed to reload configuration file");
+		if (!use_all_config_if) {
+			init_cli_if(saved_cli_if_count, saved_cli_if);
 		}
-		for (ifnamep = ifnames; ifnamep; ifnamep = ifnamep->next) {
-			if ((ifp = ifinit(ifnamep->name)) == NULL) {
-				d_printf(LOG_ERR, FNAME,
-				    "failed to initialize %s", ifnamep->name);
-				exit(1);
-			}
-		}
-		if (infreq_mode == 0 && (cfparse(conffile)) != 0) {
+		if (cfparse(conffile)) {
 			d_printf(LOG_WARNING, FNAME,
 			    "failed to reload configuration file");
 		}


### PR DESCRIPTION
Move the ifinit() calls into config.c's configure_interface() during parse
time. This removes dependence on UB and is safe across more systems. This also
removes the need to parse the config file twice.

Fixes use after free / crash on OpenBSD with -O >0.

Additionally this simplifies SIGHUP behaviour and makes it not force reload all
configured interfaces if interfaces were originally passed on the commandline.